### PR TITLE
Removes compile dependency on antlr4-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,19 +63,6 @@
 			<artifactId>antlr4-runtime</artifactId>
 			<version>${antlr4.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr4-maven-plugin</artifactId>
-			<version>${antlr4.version}</version>
-			<!-- <scope>provided</scope> -->
-			<exclusions>
-				<!-- incompatible with mock server -->
-				<exclusion>
-					<groupId>org.sonatype.sisu</groupId>
-					<artifactId>sisu-guava</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
 		<!-- adding manually due to Shell Command Injection and Directory Traversal
 		https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-1000487 
 		https://cwe.mitre.org/data/definitions/22.html --> 

--- a/src/main/java/de/ids_mannheim/korap/query/serialize/AnnisQueryProcessor.java
+++ b/src/main/java/de/ids_mannheim/korap/query/serialize/AnnisQueryProcessor.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import org.antlr.v4.parse.ANTLRParser.throwsSpec_return;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.CharStream;


### PR DESCRIPTION
The compile-/runtime dependency on `antlr4-maven-plugin` is only motivated by an unused import. Removing the import statement and the dependency reduces the resulting dependency tree of this library substantially.

Before:

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ Koral ---
[INFO] de.ids_mannheim.korap:Koral:jar:0.38.1
[INFO] +- org.antlr:antlr4-runtime:jar:4.9.3:compile
[INFO] +- org.antlr:antlr4-maven-plugin:jar:4.9.3:compile
[INFO] |  +- org.apache.maven:maven-plugin-api:jar:3.0.5:compile
[INFO] |  |  +- org.apache.maven:maven-model:jar:3.0.5:compile
[INFO] |  |  +- org.apache.maven:maven-artifact:jar:3.0.5:compile
[INFO] |  |  \- org.sonatype.sisu:sisu-inject-plexus:jar:2.3.0:compile
[INFO] |  |     +- org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile
[INFO] |  |     +- org.codehaus.plexus:plexus-classworlds:jar:2.4:compile
[INFO] |  |     \- org.sonatype.sisu:sisu-inject-bean:jar:2.3.0:compile
[INFO] |  |        \- org.sonatype.sisu:sisu-guice:jar:no_aop:3.1.0:compile
[INFO] |  +- org.codehaus.plexus:plexus-compiler-api:jar:2.2:compile
[INFO] |  +- org.sonatype.plexus:plexus-build-api:jar:0.0.7:compile
[INFO] |  +- org.antlr:antlr4:jar:4.9.3:compile
[INFO] |  |  +- org.antlr:ST4:jar:4.3.1:compile
[INFO] |  |  +- org.abego.treelayout:org.abego.treelayout.core:jar:1.0.3:compile
[INFO] |  |  +- org.glassfish:javax.json:jar:1.0.4:compile
[INFO] |  |  \- com.ibm.icu:icu4j:jar:69.1:compile
[INFO] |  \- org.apache.maven:maven-project:jar:2.2.1:compile
[INFO] |     +- org.apache.maven:maven-settings:jar:2.2.1:compile
[INFO] |     +- org.apache.maven:maven-profile:jar:2.2.1:compile
[INFO] |     +- org.apache.maven:maven-artifact-manager:jar:2.2.1:compile
[INFO] |     |  +- org.apache.maven:maven-repository-metadata:jar:2.2.1:compile
[INFO] |     |  +- org.apache.maven.wagon:wagon-provider-api:jar:1.0-beta-6:compile
[INFO] |     |  \- backport-util-concurrent:backport-util-concurrent:jar:3.1:compile
[INFO] |     +- org.apache.maven:maven-plugin-registry:jar:2.2.1:compile
[INFO] |     +- org.codehaus.plexus:plexus-interpolation:jar:1.11:compile
[INFO] |     \- org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1:compile
[INFO] |        \- classworlds:classworlds:jar:1.1-alpha-2:compile
[INFO] +- org.codehaus.plexus:plexus-utils:jar:3.4.1:compile
[INFO] +- org.antlr:antlr-runtime:jar:3.5.2:compile
[INFO] +- com.google.guava:guava:jar:31.1-jre:compile
[INFO] |  +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  +- org.checkerframework:checker-qual:jar:3.12.0:compile
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.11.0:compile
[INFO] |  \- com.google.j2objc:j2objc-annotations:jar:1.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.13.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.3:compile
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- commons-lang:commons-lang:jar:2.6:compile
[INFO] +- org.z3950.zing:cql-java:jar:1.13:compile
[INFO] +- org.apache.logging.log4j:log4j-api:jar:2.17.2:compile
[INFO] +- org.apache.logging.log4j:log4j-core:jar:2.17.2:compile
[INFO] +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.17.2:compile
[INFO] +- org.apache.logging.log4j:log4j-jul:jar:2.17.2:compile
[INFO] +- org.slf4j:slf4j-api:jar:1.7.32:compile
[INFO] \- eu.clarin.sru.fcs:fcs-simple-endpoint:jar:1.4.0:compile
[INFO]    +- eu.clarin.sru:sru-server:jar:1.8.0:compile
[INFO]    +- eu.clarin.sru.fcs:fcs-ql:jar:0.1:compile
[INFO]    \- org.codehaus.woodstox:woodstox-core-lgpl:jar:4.4.1:compile
[INFO]       \- org.codehaus.woodstox:stax2-api:jar:3.1.4:compile
```

After:

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ Koral ---
[INFO] de.ids_mannheim.korap:Koral:jar:0.38.1
[INFO] +- org.antlr:antlr4-runtime:jar:4.9.3:compile
[INFO] +- org.codehaus.plexus:plexus-utils:jar:3.4.1:compile
[INFO] +- org.antlr:antlr-runtime:jar:3.5.2:compile
[INFO] +- com.google.guava:guava:jar:31.1-jre:compile
[INFO] |  +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  +- org.checkerframework:checker-qual:jar:3.12.0:compile
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.11.0:compile
[INFO] |  \- com.google.j2objc:j2objc-annotations:jar:1.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.13.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.3:compile
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- commons-lang:commons-lang:jar:2.6:compile
[INFO] +- org.z3950.zing:cql-java:jar:1.13:compile
[INFO] +- org.apache.logging.log4j:log4j-api:jar:2.17.2:compile
[INFO] +- org.apache.logging.log4j:log4j-core:jar:2.17.2:compile
[INFO] +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.17.2:compile
[INFO] +- org.apache.logging.log4j:log4j-jul:jar:2.17.2:compile
[INFO] +- org.slf4j:slf4j-api:jar:1.7.32:compile
[INFO] \- eu.clarin.sru.fcs:fcs-simple-endpoint:jar:1.4.0:compile
[INFO]    +- eu.clarin.sru:sru-server:jar:1.8.0:compile
[INFO]    +- eu.clarin.sru.fcs:fcs-ql:jar:0.1:compile
[INFO]    \- org.codehaus.woodstox:woodstox-core-lgpl:jar:4.4.1:compile
[INFO]       \- org.codehaus.woodstox:stax2-api:jar:3.1.4:compile
```